### PR TITLE
Implement relative timestamp in PatternRenderer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ jdk:
 
 install: ./build ci-prepare -V -B -s .travis/settings.xml
 
-script: ./build ci-deploy -V -B -s .travis/settings.xml
+script:
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "true" -o "$TRAVIS_BRANCH" != "master" ] ; then ./build ci-verify -V -B -s .travis/settings.xml ; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ] ; then ./build ci-deploy -V -B -s .travis/settings.xml ; fi'

--- a/build
+++ b/build
@@ -67,6 +67,11 @@ case "$command" in
         mvn clean deploy $*
         ;;
 
+    # build and deploy for CI
+    ci-verify)
+        mvn clean verify $*
+        ;;
+
     # release automation
     release)
         version="$1"

--- a/gossip-bootstrap/pom.xml
+++ b/gossip-bootstrap/pom.xml
@@ -51,6 +51,13 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/gossip-bootstrap/src/main/java/com/planet57/gossip/render/PatternRenderer.java
+++ b/gossip-bootstrap/src/main/java/com/planet57/gossip/render/PatternRenderer.java
@@ -40,6 +40,11 @@ import com.planet57.gossip.Event;
  * </tr>
  *
  * <tr>
+ * <td><tt>%r</tt></td>
+ * <td>Relative Time-stamp since creation of PatternRenderer (since 2.0.1)</td>
+ * </tr>
+ *
+ * <tr>
  * <td><tt>%c</tt></td>
  * <td>Short logger name</td>
  * </tr>
@@ -103,6 +108,8 @@ public class PatternRenderer
 {
   private static final String NEWLINE = System.getProperty("line.separator");
 
+  private static final long PATTERN_RENDERER_START_TIME = System.currentTimeMillis();
+
   /**
    * @since 1.6
    */
@@ -163,6 +170,10 @@ public class PatternRenderer
 
           case 'd':
             renderTimeStamp(event, buff);
+            break;
+
+          case 'r':
+            renderRelativeTimeStamp(event, buff);
             break;
 
           case 'c':
@@ -233,6 +244,13 @@ public class PatternRenderer
     assert buff != null;
 
     buff.append(event.getTimeStamp());
+  }
+
+  protected void renderRelativeTimeStamp(Event event, StringBuilder buff) {
+    assert event != null;
+    assert buff != null;
+
+    buff.append(event.getTimeStamp() - PATTERN_RENDERER_START_TIME);
   }
 
   protected void renderLevel(final Event event, final StringBuilder buff) {

--- a/gossip-bootstrap/src/test/java/com/planet57/gossip/render/PatternRendererTest.java
+++ b/gossip-bootstrap/src/test/java/com/planet57/gossip/render/PatternRendererTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2009-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.planet57.gossip.render;
+
+import com.planet57.gossip.Event;
+import com.planet57.gossip.Level;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.both;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class PatternRendererTest {
+
+    @Test
+    public void renderRelative() throws Exception {
+        final long time = getTime("%r [%l] %m%n%x");
+        assertThat(time, both(greaterThanOrEqualTo(0L)).and(lessThan(10000L)));
+    }
+
+    @Test
+    public void renderAbsolute() throws Exception {
+        final long currentTimeMillis = System.currentTimeMillis();
+        final long time = getTime("%d [%l] %m%n%x");
+        assertThat(time, greaterThanOrEqualTo(currentTimeMillis));
+    }
+
+    private long getTime(String pattern) {
+        final PatternRenderer sut = new PatternRenderer(pattern);
+        final String result = sut.render(new Event(null, Level.INFO, "Hello", null));
+        assertThat(result, endsWith("[INFO] Hello\n"));
+        final String[] split = result.split(" ");
+        return Long.valueOf(split[0]);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
         <version>4.12</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+      </dependency>
+
       <!-- INTERNAL -->
 
       <dependency>


### PR DESCRIPTION
- As suggested on [dev@maven.apache.org](http://mail-archives.apache.org/mod_mbox/maven-dev/201607.mbox/%3cCAHTFAkm-uUwMq5Uh+27nqu9pDnnGrg8-bHUu8PT9T8z13gtOBA@mail.gmail.com%3e) I added a relative timestamp.
- This includes a simple test.
- Additionally I modified the build script, because it should probably only deploy to oss.sonatype.org if the commit is part of the master of the original project.
